### PR TITLE
Amended virtual host setting for apache (port only)

### DIFF
--- a/forge/Installation and Upgrading/installubuntuapachemysql.md
+++ b/forge/Installation and Upgrading/installubuntuapachemysql.md
@@ -81,7 +81,7 @@ Now, we create a virtual host named *taoplatform*. Its *DocumentRoot* is */var/w
 NameVirtualHost 127.0.0.1:80
 ServerName localhost
 
-<VirtualHost 127.0.0.1:80>
+<VirtualHost *:80>
 	ServerAdmin webmaster@taoplatform
 	ServerName taoplatform
 	DocumentRoot /var/www/taoplatform    


### PR DESCRIPTION
Perhaps it makes sense to set IP as a wildcard. For example on multiple IP hosts (i.e. AWS EC2 where there are Public and VPC IPs) this setting makes it all work out-of-the-box.