### PR TITLE
tao-4692 Migrate from ruby sass to libsass

### DIFF
--- a/forge/Documentation for core components/front-tools.md
+++ b/forge/Documentation for core components/front-tools.md
@@ -32,17 +32,6 @@ Grunt runs on node.js, so you need [node.js](https://nodejs.org/en/download/) in
     nvm install v6.2.1
     nvm alias default v6.2.1
 
-- The current SASS scripts used in TAO contains a bug, so we can’t use the libsass until it is fixed. You need then to have the sass tool available on your system:<br/>
-
-For Ubuntu/Debian user :
-
-    sudo apt-get install rubygems
-    sudo gem install sass
-
-For MacOS user, ruby comes installed to your system, you just have to install sass :
-
-    gem install sass
-
 - Then to install and set up Grunt :
 
     cd tao/views/build


### PR DESCRIPTION
@krampstudio I went for the simplest amendment first. Let me know if you'd like to see better notes on sass? My thinking was that between `npm install` and `grunt --help`, sass compilation would be self explanatory.