### PR TITLE
Fix non-working Markdown link

### DIFF
--- a/forge/How to make a new extension 3 3/how-to-make-a-new-extension-3-3.md
+++ b/forge/How to make a new extension 3 3/how-to-make-a-new-extension-3-3.md
@@ -16,7 +16,7 @@ tags:
 1. Install TAO (3.x) (https://github.com/oat-sa/package-tao)
 2. Download `taoDevTools` extension using composer:
     `composer require "oat-sa/extension-tao-devtools" —dev`
-3. Make sure the extension has been installed (See [this article](https://github.com/oat-sa/taohub-articles/blob/master/forge/Wiki/installing-a-new-extension.md).)
+3. Make sure the extension has been installed (See https://github.com/oat-sa/taohub-articles/blob/master/forge/Wiki/installing-a-new-extension.md)
 
 ## Create the extension
 


### PR DESCRIPTION
Using long url direct link as a temporary fix because the `.md` extension gets chopped off when the page is rendered on TaoHub.