### PR TITLE
Fix url for requests image

### DIFF
--- a/forge/Documentation for core components/request-tokenisation.md
+++ b/forge/Documentation for core components/request-tokenisation.md
@@ -39,7 +39,7 @@ Furthermore, a REST endpoint for such requests is expected to match the followin
 
 How are the different components of this system related?
 
-![frontend](Requests.png)
+![frontend](../resources/Requests.png)
 
 ### core/request module
 


### PR DESCRIPTION
Image on TaoHub was broken, url was pointing to the wrong place.