### PR TITLE
Feature TDR-11: One package.json per extension

### DIFF
--- a/articles/Frontend/Architecture/amd-require.md
+++ b/articles/Frontend/Architecture/amd-require.md
@@ -97,7 +97,7 @@ The configuration options can be modified through the template and the controlle
 
 ### Test and build configuration
 
-A static and lighter version of the configuration is located at `tao/views/build/config/requirejs.build.json`.
+A static and lighter version of the configuration is located at `tao/views/config/requirejs.build.json`.
 *It needs to be updated manually.*
 
 ### Module configuration

--- a/forge/Developer Guide/build.md
+++ b/forge/Developer Guide/build.md
@@ -26,7 +26,7 @@ Be sure node.js, npm, grunt and sass are available on your system. See [this sec
 
 Go to the build folder (where `{tao_dist}` is your TAO installation directory):
 
-    $> cd {tao_dist}/tao/views/build
+    $> cd {tao_dist}/tao/views
 
 Then run
 

--- a/forge/Documentation for core components/front-styling.md
+++ b/forge/Documentation for core components/front-styling.md
@@ -56,7 +56,7 @@ In order to compile (or watch) your SASS files to the target CSS, you can either
 
 #### Build using Grunt
 
-To compile the main theme, you need the Front Tools up and running. Then open a terminal into `tao/views/build`.
+To compile the main theme, you need the Front Tools up and running. Then open a terminal into `tao/views`.
 
 For example to compile CSS files for the TAO extension :
 

--- a/forge/Documentation for core components/front-tools.md
+++ b/forge/Documentation for core components/front-tools.md
@@ -33,10 +33,10 @@ Grunt runs on node.js, so you need [node.js](https://nodejs.org/en/download/) in
 
 - Then to install and set up Grunt :
 
-    cd tao/views/build
+    cd tao/views
     npm install
 
-Then you should be able to see available grunt tasks from the `tao/views/build` directory:
+Then you should be able to see available grunt tasks from the `tao/views` directory:
 
     grunt --help
 

--- a/forge/Unit-tests.md
+++ b/forge/Unit-tests.md
@@ -13,7 +13,7 @@ JavaScript unit tests
 Setup
 -----
 
-    cd tao/views/build
+    cd tao/views
     npm install
 
 Running tests
@@ -25,7 +25,7 @@ Running tests
 
 ### Specific extension:
 
-    cd tao/views/build
+    cd tao/views
     grunt connect:test [extname+test]
     grunt connect:test taoqtiitemtest
     grunt connect:test taotest
@@ -35,7 +35,7 @@ Running tests
 
 You can either open the test.html in a browser or adapt the following command line:
 
-    cd tao/views/build
+    cd tao/views
     grunt connect:test qunit:single --test=[/path/to/test.html]
     grunt connect:test qunit:single --test=/taoQtiItem/views/js/qtiCreator/test/MathEditor/test.html
     ...

--- a/forge/pci-development.md
+++ b/forge/pci-development.md
@@ -148,7 +148,7 @@ grunt portableelement --extension=extensionName (--identifier=interactionTypeIde
 grunt portableelement -e=extensionName (-i=interactionTypeIdentifier)
 
 #Real example:
-cd tao/views/build
+cd tao/views
 grunt portableelement -e=qtiItemPci -i=likertScaleInteraction
 ```
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TDR-11

Updated documents that touch the build assets process. Changed mentions about `tao/views/build` directory to `tao/views`.

### Merge after
- [tao-cope PR #2388](https://github.com/oat-sa/tao-core/pull/2388)
